### PR TITLE
allow notifications to be added as another event

### DIFF
--- a/trigger.go
+++ b/trigger.go
@@ -48,6 +48,42 @@ func (t *Trigger) AddEventObject(event string, details map[string]any) *Trigger 
 	return t.add(eventContent{event: event, data: details})
 }
 
+func (t *Trigger) AddSuccess(message string, vars ...map[string]any) {
+	t.addNotifyObject(notificationSuccess, message, vars...)
+}
+
+func (t *Trigger) AddInfo(message string, vars ...map[string]any) {
+	t.addNotifyObject(notificationInfo, message, vars...)
+}
+
+func (t *Trigger) AddWarning(message string, vars ...map[string]any) {
+	t.addNotifyObject(notificationWarning, message, vars...)
+}
+
+func (t *Trigger) AddError(message string, vars ...map[string]any) {
+	t.addNotifyObject(notificationError, message, vars...)
+}
+
+func (t *Trigger) addNotifyObject(nt notificationType, message string, vars ...map[string]any) *Trigger {
+	details := map[string]any{
+		notificationKeyLevel:   nt,
+		notificationKeyMessage: message,
+	}
+
+	if len(vars) > 0 {
+		for _, m := range vars {
+			for k, v := range m {
+				if k == notificationKeyLevel || k == notificationKeyMessage {
+					k = "_" + k
+				}
+				details[k] = v
+			}
+		}
+	}
+
+	return t.AddEventObject(DefaultNotificationKey, details)
+}
+
 // String returns the string representation of the Trigger set
 func (t *Trigger) String() string {
 	if t.onlySimple {
@@ -90,24 +126,7 @@ func (n *notificationType) String() string {
 }
 
 func (h *Handler) notifyObject(nt notificationType, message string, vars ...map[string]any) {
-	details := map[string]any{
-		notificationKeyLevel:   nt,
-		notificationKeyMessage: message,
-	}
-
-	if len(vars) > 0 {
-		for _, m := range vars {
-			for k, v := range m {
-				if k == notificationKeyLevel || k == notificationKeyMessage {
-					k = "_" + k
-				}
-				details[k] = v
-			}
-		}
-	}
-
-	t := NewTrigger().AddEventObject(DefaultNotificationKey, details)
-
+	t := NewTrigger().addNotifyObject(nt, message, vars...)
 	h.TriggerWithObject(t)
 }
 

--- a/trigger_test.go
+++ b/trigger_test.go
@@ -52,9 +52,8 @@ func TestNewTriggerMixedNested(t *testing.T) {
 	trigger.AddEvent("foo").
 		AddEventDetailed("bar", "baz").
 		AddEventDetailed("qux", "quux").
-		AddEventObject("corge", map[string]any{"grault": "garply", "waldo": "fred", "plugh": "xyzzy", "thud": map[string]any{"foo": "bar", "baz": "qux"}})
-
-	expected := `{"bar":"baz","corge":{"grault":"garply","plugh":"xyzzy","thud":{"baz":"qux","foo":"bar"},"waldo":"fred"},"foo":"","qux":"quux"}`
+		AddEventObject("corge", map[string]any{"grault": "garply", "waldo": "fred", "plugh": "xyzzy", "thud": map[string]any{"foo": "bar", "baz": "qux"}}).AddSuccess("successfully tested", map[string]any{"foo": "bar", "baz": "qux"})
+	expected := `{"bar":"baz","corge":{"grault":"garply","plugh":"xyzzy","thud":{"baz":"qux","foo":"bar"},"waldo":"fred"},"foo":"","qux":"quux","showMessage":{"baz":"qux","foo":"bar","level":"success","message":"successfully tested"}}`
 
 	if trigger.String() != expected {
 		t.Errorf("expected trigger to be %v, got %v", expected, trigger.String())


### PR DESCRIPTION
Hi, 
I hit a usecase where I wanted to send in one response a Success notification to a user and also second event so that HTMX can fetch new data.

I moved logic composing notify object from the handler ```notifyObject``` into a new method ```addNotifyObject``` in Trigger struct. This struct also now exposes public methods like AddSuccess, AddInfo, AddError etc.. 

So that composing triggers like below will be possible:

```go
trigger := htmx.NewTrigger()
trigger.AddEvent("fl:record:updated")
trigger.AddSuccess("Transcription updated")
hx.TriggerWithObject(trigger)
```

Also I added tests for a good measure. :-)