### PR TITLE
Fixed render example

### DIFF
--- a/examples/render/main.go
+++ b/examples/render/main.go
@@ -29,8 +29,8 @@ func main() {
 
 	htmx.UseTemplateCache = false
 
-	http.HandleFunc("/", app.Home)
-	http.HandleFunc("/child", app.Child)
+	mux.HandleFunc("/", app.Home)
+	mux.HandleFunc("/child", app.Child)
 
 	err := http.ListenAndServe(":3210", mux)
 	log.Fatal(err)

--- a/examples/render/sidebar.html
+++ b/examples/render/sidebar.html
@@ -1,6 +1,10 @@
 {{ $self := . }}
-<div hx-boost="true" hx-target="#content" _="on click take .bg-blue-500  from .block  for the event's target">
+<div hx-boost="true" hx-target="#content" >
 {{ range $target := .Data.MenuItems }}
-    <a href="{{ $target.Link }}" class="cursor-pointer block rounded rounded-md p-4 my-2 {{ if eq $self.URL.Path $target.Link }} bg-blue-500 {{ end }}">{{ $target.Name }}</a>
+    <a 
+        href="{{ $target.Link }}" 
+        class="cursor-pointer block rounded rounded-md p-4 my-2 {{ if eq $self.URL.Path $target.Link }} bg-blue-500 {{ end }}"
+        _="on click take .bg-blue-500 from .block for the event's target"
+        >{{ $target.Name }}</a>
 {{ end }}
 </div>


### PR DESCRIPTION
This Pullrequest fixes two issuse in the 'render' example:

1. When trying out the example, I noticed that route handling in main.go was assigned to the http module instead of the mux object, which resulted in 404 responses for me for all routes.

2. Clicking the space between the 'Home' and 'Child' links in the sidebar results in the parent container receiving the bg-blue-500 class, breaking the highlighting system for subsequent clicks.
Moving the hyperscript snippet to the link item fixed this. 
