### PR TITLE
Remove debug print statement from SSE message formatting

### DIFF
--- a/sse/sse.go
+++ b/sse/sse.go
@@ -72,8 +72,6 @@ func (m *Message) String() string {
 	}
 	sb.WriteString(fmt.Sprintf("data: %v\n\n", m.Data))
 
-	fmt.Println(sb.String())
-
 	return sb.String()
 }
 


### PR DESCRIPTION
It looks like a fmt.Println slipped into the code